### PR TITLE
Create Makefile for churn

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,3 +75,23 @@ jobs:
         run: |
           make cache
           python -m pytest
+
+  test-makefile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Tor
+        run: sudo apt-get install -y tor
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Run Makefile
+        working-directory: ./tools
+        env:
+          DIR_AUTH_PASSWORD: dummy
+        run: |
+          make cache
+          make update_cache_churn

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,6 @@ jobs:
         env:
           DIR_AUTH_PASSWORD: dummy
         run: |
-          make dirinfo
           make churn
 
       - uses: actions-rs/toolchain@v1
@@ -74,5 +73,5 @@ jobs:
         env:
           DIR_AUTH_PASSWORD: dummy
         run: |
-          make dirinfo
+          make cache
           python -m pytest

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,3 +1,3 @@
 authority-private/
 directory-cache/
-pip_install
+.venv

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -10,19 +10,20 @@ CACHE_CERT=$(CACHE_DIR)/certificate.txt
 CACHE_AUTH=$(CACHE_DIR)/authority.txt
 CACHE_CONS=$(CACHE_DIR)/consensus.txt
 CACHE_MICRO=$(CACHE_DIR)/microdescriptors.txt
+CACHE_CHURN=$(CACHE_DIR)/churn.txt
 
 all: update_cache
 
 clean_auth:
 	rm -rf $(AUTH_DIR)
 
-authority: pip_install $(AUTH_ID) $(AUTH_SIGN) $(AUTH_CERT) $(AUTH_AUTH)
+authority: .venv $(AUTH_ID) $(AUTH_SIGN) $(AUTH_CERT) $(AUTH_AUTH)
 $(AUTH_ID) $(AUTH_SIGN) $(AUTH_CERT) $(AUTH_AUTH):
 ifeq ($(DIR_AUTH_PASSWORD), )
 	$(error Environment variable DIR_AUTH_PASSWORD is undefined or invalid.)
 endif
 	mkdir -p $(AUTH_DIR)
-	./gen_fresh_dirinfo.py generate-certificate \
+	. .venv/bin/activate && ./gen_fresh_dirinfo.py generate-certificate \
 		--authority-identity-key $(AUTH_ID) \
 		--authority-signing-key $(AUTH_SIGN) \
 		--authority-certificate $(AUTH_CERT) \
@@ -33,25 +34,25 @@ clean_cache:
 
 update_cache: clean_cache cache
 
-cache: $(CACHE_CERT) $(CACHE_AUTH) $(CACHE_CONS) $(CACHE_MICRO)
+cache: authority $(CACHE_CERT) $(CACHE_AUTH) $(CACHE_CONS) $(CACHE_MICRO)
 $(CACHE_CERT) $(CACHE_AUTH) $(CACHE_CONS) $(CACHE_MICRO):
 	$(MAKE) authority
 	mkdir -p $(CACHE_DIR)
 	cp $(AUTH_CERT) $(AUTH_AUTH) $(CACHE_DIR)
-	./gen_fresh_dirinfo.py generate-dirinfo \
+	. .venv/bin/activate && ./gen_fresh_dirinfo.py generate-dirinfo \
 		--authority-signing-key $(AUTH_SIGN) \
 		--authority-certificate $(CACHE_CERT) \
 		--consensus $(CACHE_CONS) \
 		--microdescriptors $(CACHE_MICRO)
 
 churn: cache
-	./gen_fresh_dirinfo.py compute-churn \
-		--consensus $(CACHE_DIR)/consensus.txt \
-		--churn $(CACHE_DIR)/churn.txt
+	. .venv/bin/activate && ./gen_fresh_dirinfo.py compute-churn \
+		--consensus $(CACHE_CONS) \
+		--churn $(CACHE_CHURN)
 
-pip_install: requirements.txt
-	pip3 install -qr requirements.txt
-	touch pip_install
+.venv: requirements.txt
+	python3 -m venv .venv
+	. .venv/bin/activate &&	pip3 install -qr requirements.txt
 
 clean: clean_cache clean_auth
 
@@ -64,14 +65,13 @@ secrets_authority: $(AUTH_DIR)
 # This updates the CACHE_DIR directory:
 # - fully every Monday or if the consensus is missing
 # - creating a new churn.txt on every day
-# It supposes that the
+# If this is called in a script, the CACHE_DIR should hold the
+# consensus for the source of the churn-file.
 CHURN_WEEK_FILE = $(CACHE_DIR)/churn_week
 CHURN_WEEK := $(shell date +%Y_%W)
 update_cache_churn: $(CHURN_WEEK_FILE)
-	if grep -v $(CHURN_WEEK) $(CHURN_WEEK_FILE); then \
-		rm -f $(CACHE_DIR)/*; \
-	fi
-	if [ $$( date +%w ) = 1 ]; then \
+	if grep -v $(CHURN_WEEK) $(CHURN_WEEK_FILE) || \
+		[ $$( date +%w ) -eq 1 ]; then \
   		rm -f $(CACHE_DIR)/*; \
 	fi
 	$(MAKE) churn $(CHURN_WEEK_FILE)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,45 +1,80 @@
-.PHONY: dirinfo check-password
+.PHONY: churn clean clean_auth clean_cache secrets_authority update_cache_churn
 
 AUTH_DIR=authority-private
-DIR_CACHE=directory-cache
+AUTH_ID=$(AUTH_DIR)/authority_identity_key
+AUTH_SIGN=$(AUTH_DIR)/authority_signing_key
+AUTH_CERT=$(AUTH_DIR)/certificate.txt
+AUTH_AUTH=$(AUTH_DIR)/authority.txt
+CACHE_DIR=directory-cache
+CACHE_CERT=$(CACHE_DIR)/certificate.txt
+CACHE_AUTH=$(CACHE_DIR)/authority.txt
+CACHE_CONS=$(CACHE_DIR)/consensus.txt
+CACHE_MICRO=$(CACHE_DIR)/microdescriptors.txt
 
-all: dirinfo
+all: update_cache
 
-$(AUTH_DIR): pip_install check-password
+clean_auth:
+	rm -rf $(AUTH_DIR)
+
+authority: pip_install $(AUTH_ID) $(AUTH_SIGN) $(AUTH_CERT) $(AUTH_AUTH)
+$(AUTH_ID) $(AUTH_SIGN) $(AUTH_CERT) $(AUTH_AUTH):
+ifeq ($(DIR_AUTH_PASSWORD), )
+	$(error Environment variable DIR_AUTH_PASSWORD is undefined or invalid.)
+endif
 	mkdir -p $(AUTH_DIR)
-	mkdir -p $(DIR_CACHE)
 	./gen_fresh_dirinfo.py generate-certificate \
-		--authority-identity-key $(AUTH_DIR)/authority_identity_key \
-		--authority-signing-key $(AUTH_DIR)/authority_signing_key \
-		--authority-certificate $(DIR_CACHE)/certificate.txt \
-		--authority-v3ident $(DIR_CACHE)/authority.txt
+		--authority-identity-key $(AUTH_ID) \
+		--authority-signing-key $(AUTH_SIGN) \
+		--authority-certificate $(AUTH_CERT) \
+		--authority-v3ident $(AUTH_AUTH)
 
-dirinfo: $(AUTH_DIR)
+clean_cache:
+	rm -rf $(CACHE_DIR)
+
+update_cache: clean_cache cache
+
+cache: $(CACHE_CERT) $(CACHE_AUTH) $(CACHE_CONS) $(CACHE_MICRO)
+$(CACHE_CERT) $(CACHE_AUTH) $(CACHE_CONS) $(CACHE_MICRO):
+	$(MAKE) authority
+	mkdir -p $(CACHE_DIR)
+	cp $(AUTH_CERT) $(AUTH_AUTH) $(CACHE_DIR)
 	./gen_fresh_dirinfo.py generate-dirinfo \
-		--authority-signing-key $(AUTH_DIR)/authority_signing_key \
-		--authority-certificate $(DIR_CACHE)/certificate.txt \
-		--consensus $(DIR_CACHE)/consensus.txt \
-		--microdescriptors $(DIR_CACHE)/microdescriptors.txt
+		--authority-signing-key $(AUTH_SIGN) \
+		--authority-certificate $(CACHE_CERT) \
+		--consensus $(CACHE_CONS) \
+		--microdescriptors $(CACHE_MICRO)
 
-churn: $(DIR_CACHE)/consensus.txt
+churn: cache
 	./gen_fresh_dirinfo.py compute-churn \
-		--consensus $(DIR_CACHE)/consensus.txt \
-		--churn $(DIR_CACHE)/churn.txt
+		--consensus $(CACHE_DIR)/consensus.txt \
+		--churn $(CACHE_DIR)/churn.txt
 
 pip_install: requirements.txt
 	pip3 install -qr requirements.txt
 	touch pip_install
 
-clean:
-	rm -rf $(AUTH_DIR) $(DIR_CACHE)
-
-check-password:
-ifeq ($(DIR_AUTH_PASSWORD), )
-	$(error Environment variable DIR_AUTH_PASSWORD is undefined or invalid.)
-endif
+clean: clean_cache clean_auth
 
 secrets_authority: $(AUTH_DIR)
-	tar cjf auth.tgz $(AUTH_DIR) $(DIR_CACHE)/{certificate.txt,authority.txt}
+	tar cjf auth.tgz $(AUTH_DIR) $(CACHE_DIR)/{certificate.txt,authority.txt}
 	base64 -i auth.tgz
 	rm auth.tgz
 	echo $$DIR_AUTH_PASSWORD
+
+# This updates the CACHE_DIR directory:
+# - fully every Monday or if the consensus is missing
+# - creating a new churn.txt on every day
+# It supposes that the
+CHURN_WEEK_FILE = $(CACHE_DIR)/churn_week
+CHURN_WEEK := $(shell date +%Y_%W)
+update_cache_churn: $(CHURN_WEEK_FILE)
+	if grep -v $(CHURN_WEEK) $(CHURN_WEEK_FILE); then \
+		rm -f $(CACHE_DIR)/*; \
+	fi
+	if [ $$( date +%w ) = 1 ]; then \
+  		rm -f $(CACHE_DIR)/*; \
+	fi
+	$(MAKE) churn $(CHURN_WEEK_FILE)
+
+$(CHURN_WEEK_FILE):
+	echo $(CHURN_WEEK) > $@

--- a/tools/README.md
+++ b/tools/README.md
@@ -59,7 +59,7 @@ directory authority are written to the sub-directory `authority-private`.
 To generate an updated custom consensus containing fresh directory information, run:
 
 ```
-make dirinfo
+make update_cache
 ```
 
 The Makefile writes the resulting files to the `directory-cache/` directory. Lightarti-rest relies on the files in this directory for its operation. Apps should download this directory and supply it as the `cache_dir` argument.


### PR DESCRIPTION
Put the churn update in the Makefile. As this required more previsible
behavior of the certificate and cache, most of the Makefile has been
rewritten.

Related to c4dt/lightarti-directory#4