### PR TITLE
Fixes

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -82,7 +82,7 @@ impl Client {
             .write_all(&raw_request)
             .await
             .context("write request")?;
-        tls_stream.shutdown().await.context("stream shutdown")?;
+        tls_stream.flush().await.context("flush")?;
 
         let mut raw_response = Vec::new();
         let read_response = tls_stream.read_to_end(&mut raw_response).await;

--- a/src/http.rs
+++ b/src/http.rs
@@ -44,7 +44,7 @@ pub fn request_to_raw(req: Request<Vec<u8>>) -> Result<Vec<u8>> {
 
 /// Deserialize an raw HTTP response to an [`Response`]
 pub fn raw_to_response(mut raw_resp: Vec<u8>) -> Result<Response<Vec<u8>>> {
-    const MAX_HEADERS: usize = 16;
+    const MAX_HEADERS: usize = 64;
 
     let mut headers = [httparse::EMPTY_HEADER; MAX_HEADERS];
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -5,7 +5,7 @@ use http::{Request, Response};
 
 /// Serialize a [`Request`] as an raw HTTP request
 pub fn request_to_raw(req: Request<Vec<u8>>) -> Result<Vec<u8>> {
-    const EOL: &str = "\n";
+    const EOL: &str = "\r\n";
 
     let (parts, mut body) = req.into_parts();
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -25,6 +25,27 @@ pub async fn test_get() {
 }
 
 #[tokio::test]
+pub async fn test_get_long_response() {
+    utils::setup_tracing();
+    let cache = utils::setup_cache();
+
+    let resp = Client::new(cache.path())
+        .await
+        .expect("create client")
+        .send(
+            Request::get("https://www.admin.ch/gov/de/start.html")
+                .header("Host", "www.admin.ch")
+                .version(http::Version::HTTP_10)
+                .body(vec![])
+                .expect("create get request"),
+        )
+        .await
+        .expect("send request");
+
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
 pub async fn test_post() {
     utils::setup_tracing();
     let cache = utils::setup_cache();

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -46,6 +46,27 @@ pub async fn test_get_long_response() {
 }
 
 #[tokio::test]
+pub async fn test_get_many_headers() {
+    utils::setup_tracing();
+    let cache = utils::setup_cache();
+
+    let resp = Client::new(cache.path())
+        .await
+        .expect("create client")
+        .send(
+            Request::get("https://www.sunrise.ch/en/home")
+                .header("Host", "www.sunrise.ch")
+                .version(http::Version::HTTP_10)
+                .body(vec![])
+                .expect("create get request"),
+        )
+        .await
+        .expect("send request");
+
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
 pub async fn test_post() {
     utils::setup_tracing();
     let cache = utils::setup_cache();


### PR DESCRIPTION
The first commit fixes #92 (not actually for `c4dt.org` but for other sites that failed with a 499 status code).

The EOL fix is for conformity with the RFC, even though it seems that many servers are tolerant.

The increased header limit is because I ran into this issue with the `sunrise.ch` site...