### PR TITLE
github/lint-build-test: patch cargo-ndk

### DIFF
--- a/.github/workflows/lint-build-test.yaml
+++ b/.github/workflows/lint-build-test.yaml
@@ -75,6 +75,11 @@ jobs:
           command: install
           args: cargo-ndk
 
+      - name: patch bbqsrc/cargo-ndk#22
+        run: >
+          find -L /usr/local/lib/android/sdk/ndk-bundle -name libunwind.a
+          -execdir sh -c 'echo "INPUT(-lunwind)" > libgcc.a' \;
+
       - uses: actions-rs/cargo@v1
         with:
           command: ndk


### PR DESCRIPTION
Rust is moving away from gcc in favor of libunwind, but prebuild std for some platform (such as Android) are still using it. This patch creates the needed indirection `gcc -> unwind`.

See https://github.com/bbqsrc/cargo-ndk/issues/22

Fixes #103 