### PR TITLE
Fixing Cargo.toml version and passing tests

### DIFF
--- a/.github/workflows/lint-build-test.yaml
+++ b/.github/workflows/lint-build-test.yaml
@@ -1,9 +1,6 @@
 name: Lint, build and test
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 jobs:
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.4.4 - 2022/08/26
+	* Moving back version-# in Cargo.toml to 0.4.4
+
+0.4.3 - 2022/08/04
+	* Updating to arti 0.6
+	* Fixing iOS compilation errors
+
 0.4.2 - 2022/04/14
 	* Update roadmap in README
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs-mistrust"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +1085,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,6 +1235,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
+ "url",
  "webpki-roots",
 ]
 
@@ -1246,6 +1268,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -1459,6 +1487,12 @@ checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
 dependencies = [
  "base64ct",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "phf"
@@ -2283,6 +2317,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "tokio"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2922,10 +2971,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -2938,6 +3002,18 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "users"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "lightarti-rest"
-version = "0.5.0"
+version = "0.4.4"
 dependencies = [
  "android_logger",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightarti-rest"
-version = "0.5.0"
+version = "0.4.4"
 authors = [
     "Linus Gasser <linus.gasser@epfl.ch>",
     "Laurent Girod <laurent.girod@epfl.ch>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-rustls = "0.23"
 tracing = "0.1"
 webpki-roots = "0.22"
+url = "2"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ following constraints:
 This allows us to quickly verify that a given library version has at least some patches
 from the lightarti-rest code by simply looking at the version number.
 
+### Releasing a new version
+
+To release a new version, simply add a new tag to the repo and push it:
+
+```
+git tag 0.4.4
+git push --tag
+```
+
+The github-workflow will then create a new release.
+Please make sure that the version fits the above constraints.
+
 ## Directories
 
 - `./` is the rust library for the wrapper with arti

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -68,12 +68,12 @@ async fn test_client(req: Request<Vec<u8>>) {
                 .send(request)
                 .await;
 
-            match resp {
-                Ok(resp) => (resp.status() == 200)
+            resp.and_then(|r| {
+                (r.status() == 200)
                     .then_some(())
-                    .ok_or_else(|| anyhow::anyhow!("Wrong status")),
-                Err(e) => Err(anyhow::anyhow!("Couldn't get response: {}", e)),
-            }
+                    .ok_or(anyhow::anyhow!("wrong status"))
+            })
+            .context("send request")
         })
     })
     .await

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,88 +1,99 @@
+use http::request::{Builder, Parts};
 use http::Request;
 use lightarti_rest::Client;
+use url::Url;
 
 mod utils;
 
+const MAX_TRIES: u32 = 4;
+
 #[tokio::test]
-pub async fn test_get() {
-    utils::setup_tracing();
-    let cache = utils::setup_cache();
-
-    let resp = Client::new(cache.path())
-        .await
-        .expect("create client")
-        .send(
-            Request::get("https://www.example.com")
-                .header("Host", "www.example.com")
-                .version(http::Version::HTTP_10)
-                .body(vec![])
-                .expect("create get request"),
-        )
-        .await
-        .expect("send request");
-
-    assert_eq!(resp.status(), 200);
+pub async fn test_get_short() {
+    test_get("https://www.example.com").await;
 }
 
 #[tokio::test]
 pub async fn test_get_long_response() {
-    utils::setup_tracing();
-    let cache = utils::setup_cache();
-
-    let resp = Client::new(cache.path())
-        .await
-        .expect("create client")
-        .send(
-            Request::get("https://www.admin.ch/gov/de/start.html")
-                .header("Host", "www.admin.ch")
-                .version(http::Version::HTTP_10)
-                .body(vec![])
-                .expect("create get request"),
-        )
-        .await
-        .expect("send request");
-
-    assert_eq!(resp.status(), 200);
+    test_get("https://www.admin.ch/gov/de/start.html").await;
 }
 
 #[tokio::test]
 pub async fn test_get_many_headers() {
-    utils::setup_tracing();
-    let cache = utils::setup_cache();
-
-    let resp = Client::new(cache.path())
-        .await
-        .expect("create client")
-        .send(
-            Request::get("https://www.sunrise.ch/en/home")
-                .header("Host", "www.sunrise.ch")
-                .version(http::Version::HTTP_10)
-                .body(vec![])
-                .expect("create get request"),
-        )
-        .await
-        .expect("send request");
-
-    assert_eq!(resp.status(), 200);
+    test_get("https://www.sunrise.ch/en/home").await;
 }
 
 #[tokio::test]
 pub async fn test_post() {
+    test_client(
+        Request::post("https://httpbin.org/post")
+            .header("Host", "httpbin.org")
+            .version(http::Version::HTTP_10)
+            .body(Vec::from("key1=val1&key2=val2"))
+            .expect("Couldn't build request"),
+    )
+    .await;
+}
+
+// Creates a GET request from an URI and calls test_client on it.
+async fn test_get(uri: &str) {
+    let url = Url::parse(uri).unwrap();
+
+    test_client(
+        Request::get(uri)
+            .header("Host", url.host_str().unwrap())
+            .version(http::Version::HTTP_10)
+            .body(vec![])
+            .map_err(|e| anyhow::anyhow!("Error in request: {}", e))
+            .expect("Couldn't build request"),
+    )
+    .await;
+}
+
+// Calls the lightarti-rest code up to MAX_TRIES to get a correct answer.
+// Returns on the first correct answer, or throws a panic if all MAX_TRIES failed.
+// This is necessary due to the sometimes erratic behaviour of the tor-nodes.
+async fn test_client(req: Request<Vec<u8>>) {
     utils::setup_tracing();
-    let cache = utils::setup_cache();
+    let (header, body) = req.into_parts();
+    let host = header.uri.clone();
 
-    let resp = Client::new(cache.path())
-        .await
-        .expect("create client")
-        .send(
-            Request::post("https://httpbin.org/post")
-                .header("Host", "httpbin.org")
-                .version(http::Version::HTTP_10)
-                .body(Vec::from("key1=val1&key2=val2"))
-                .expect("create post request"),
+    utils::test_n(MAX_TRIES, move || {
+        let request = clone_request(&header, &body);
+        Box::pin(async move {
+            let cache = utils::setup_cache();
+
+            let resp = Client::new(cache.path())
+                .await
+                .expect("create client")
+                .send(request)
+                .await;
+
+            match resp {
+                Ok(resp) => (resp.status() == 200)
+                    .then_some(())
+                    .ok_or_else(|| anyhow::anyhow!("Wrong status")),
+                Err(e) => Err(anyhow::anyhow!("Couldn't get response: {}", e)),
+            }
+        })
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "Didn't manage to pass in {} steps for domain {}",
+            MAX_TRIES, host
         )
-        .await
-        .expect("send request");
+    });
+}
 
-    assert_eq!(resp.status(), 200);
+fn clone_request(header: &Parts, body: &[u8]) -> Request<Vec<u8>> {
+    let mut builder = Builder::new()
+        .method(header.method.clone())
+        .uri(header.uri.clone())
+        .version(header.version);
+    let builder_header = builder.headers_mut().unwrap();
+    for header in header.headers.clone() {
+        builder_header.insert(header.0.unwrap(), header.1);
+    }
+
+    builder.body(body.to_vec()).unwrap()
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,5 +1,3 @@
-use std::future::Future;
-use std::pin::Pin;
 use std::{fs::copy, path::Path};
 use tempdir::TempDir;
 
@@ -46,21 +44,4 @@ pub fn setup_cache() -> TempDir {
     .expect("copy temp microdescriptors file");
 
     tempdir
-}
-
-pub async fn test_n(
-    n: u32,
-    p: impl Fn() -> Pin<Box<dyn Future<Output = anyhow::Result<()>>>>,
-) -> anyhow::Result<()> {
-    for i in 1..=n {
-        if let Err(e) = p().await {
-            tracing::warn!("Call failed in step {} / {}: {:?}", i, n, e)
-        } else {
-            return Ok(());
-        }
-    }
-    Err(anyhow::anyhow!(
-        "Couldn't find a working test in {} tests",
-        n
-    ))
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+use std::pin::Pin;
 use std::{fs::copy, path::Path};
 use tempdir::TempDir;
 
@@ -44,4 +46,21 @@ pub fn setup_cache() -> TempDir {
     .expect("copy temp microdescriptors file");
 
     tempdir
+}
+
+pub async fn test_n(
+    n: u32,
+    p: impl Fn() -> Pin<Box<dyn Future<Output = anyhow::Result<()>>>>,
+) -> anyhow::Result<()> {
+    for i in 1..=n {
+        if let Err(e) = p().await {
+            tracing_log::log::warn!("Call failed in step {} / {}: {:?}", i, n, e)
+        } else {
+            return Ok(());
+        }
+    }
+    Err(anyhow::anyhow!(
+        "Couldn't find a working test in {} tests",
+        n
+    ))
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -54,7 +54,7 @@ pub async fn test_n(
 ) -> anyhow::Result<()> {
     for i in 1..=n {
         if let Err(e) = p().await {
-            tracing_log::log::warn!("Call failed in step {} / {}: {:?}", i, n, e)
+            tracing::warn!("Call failed in step {} / {}: {:?}", i, n, e)
         } else {
             return Ok(());
         }


### PR DESCRIPTION
For an unknown reason I decided to bump the Cargo.toml version to 0.5.0, but this
is not what is defined in the roadmap.

So moved back to version 0.4.4, added some comments, and removed the testing/linting from push to main,
as the branch is protected now.

Also fixes #108 