### PR TITLE
fix: fix build script to take env variables into account

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ cargo test
 
 # Notes on building the library for x86_64 devices
 
-To build this library for a x86_64 device, Android NDK version 25.2.9519653 must be installed at the
-default installation path (`$HOME/Android/Sdk/ndk`).
+To build this library for a x86_64 device, Android NDK version 25.2.9519653 must be installed and
+the installation location must be pointed to in the `ANDROID_NDK_HOME` environment variable.
 
 # License
 

--- a/build.rs
+++ b/build.rs
@@ -1,15 +1,27 @@
-// inspired by https://github.com/p2panda/meli/pull/21/files
+// adapted version of meli's fix https://github.com/p2panda/meli/pull/21/files
 
 use std::env;
+use std::path;
 
 fn main() {
-    // NDK > 25 does not link to `libgcc` anymore
-    // see https://github.com/p2panda/meli/pull/21/files
     if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "x86_64"
         && env::var("CARGO_CFG_TARGET_OS").unwrap() == "android"
     {
-        let home: String = env::var("HOME").unwrap();
-        println!("cargo:rustc-link-search={home}/Android/Sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/linux-x86_64/lib64/clang/14.0.7/lib/linux/");
+        const VERSION: &str = "25.2.9519653";
+        let mut android_ndk_home: String = env::var("ANDROID_NDK_HOME").unwrap();
+        // check if default version is pinned version
+        if !android_ndk_home.contains(VERSION) {
+            let mut splits: Vec<&str> = android_ndk_home.as_str().split('/').collect();
+            splits.pop(); // remove default version
+            android_ndk_home = format!("{}/{}", &splits.join("/"), VERSION);
+        }
+        if !path::Path::new(&android_ndk_home).exists() {
+            panic!(
+                "build cannot succeed: '{}' does not exist",
+                android_ndk_home
+            );
+        }
+        println!("cargo:rustc-link-search={android_ndk_home}/toolchains/llvm/prebuilt/linux-x86_64/lib64/clang/14.0.7/lib/linux/");
         println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
     }
 }


### PR DESCRIPTION
This PR fixes the build script by:

* incorporating the ANDROID_NDK_HOME env variable that is set in the CI's image and can be set by the user to point to their location
* if it points to another version, trying whether the required version is installed and using that